### PR TITLE
Added support for UpdateDNSRecord

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,12 +90,12 @@ func main() {
 	existingRecords := recordCollection(records)
 
 	// Find records only present at cloudflare - and records only present in
-	// the local zone. This will be the basis for the add/delete collections.
+	// the file zone. This will be the basis for the add/delete collections.
 	addCandidates := fileRecords.Difference(existingRecords, FullMatch)
 	deleteCandidates := existingRecords.Difference(fileRecords, FullMatch)
 
-	// If we find the intersection between local and remote, we should have a
-	// list of records to update. We use only Updatable here, because that
+	// If we find the intersection between file and existing, we should have
+	// a list of records to update. We use only Updatable here, because that
 	// will give us a collection of records that makes sense to update.
 	updates := deleteCandidates.Intersect(addCandidates, Updatable)
 

--- a/main.go
+++ b/main.go
@@ -99,7 +99,8 @@ func main() {
 	// will give us a collection of records that makes sense to update.
 	updates := deleteCandidates.Intersect(addCandidates, Updatable)
 
-	// The changed records can be removed from the add and delete slices.
+	// The records to be updated can be removed from the add and delete
+	// collections.
 	adds := addCandidates.Difference(updates, Updatable)
 	deletes := deleteCandidates.Difference(updates, Updatable)
 

--- a/main.go
+++ b/main.go
@@ -97,13 +97,13 @@ func main() {
 	deleteCandidates := existingRecords.Difference(fileRecords, FullMatch)
 
 	// If we find the intersection between local and remote, we should have a
-	// list of records to update. We use only BasicMatch here, because that
+	// list of records to update. We use only Updatable here, because that
 	// will give us a collection of records that makes sense to update.
-	updates := deleteCandidates.Intersect(addCandidates, BasicMatch)
+	updates := deleteCandidates.Intersect(addCandidates, Updatable)
 
 	// The changed records can be removed from the add and delete slices.
-	adds := addCandidates.Difference(updates, BasicMatch)
-	deletes := deleteCandidates.Difference(updates, BasicMatch)
+	adds := addCandidates.Difference(updates, Updatable)
+	deletes := deleteCandidates.Difference(updates, Updatable)
 
 	numChanges := len(updates) + len(adds) + len(deletes)
 

--- a/main.go
+++ b/main.go
@@ -87,8 +87,6 @@ func main() {
 		fmt.Fprintf(stderr, "Can't get zone records for '%s': %s\n", id, err.Error())
 		exit(1)
 	}
-
-	// Cast the records from Cloudflare to a recordCollection.
 	existingRecords := recordCollection(records)
 
 	// Find records only present at cloudflare - and records only present in

--- a/recordCollection.go
+++ b/recordCollection.go
@@ -64,6 +64,8 @@ func (c recordCollection) Difference(remote recordCollection, match FilterFunc) 
 // Intersect will find the intersection between c and remote [c ∩ remote] with
 // the caveat that the ID from c will be used in the result - while all other
 // properties will be copied from remote.
+// If multiple record from a collection matches, only one will be present in
+// the returned collection.
 func (c recordCollection) Intersect(remote recordCollection, match FilterFunc) recordCollection {
 	// Clone the inputs - we do this to be able to remove from these
 	// collections when a match is found.

--- a/recordCollection.go
+++ b/recordCollection.go
@@ -12,10 +12,28 @@ import (
 
 type (
 	recordCollection []cloudflare.DNSRecord
+
+	// FilterFunc is used for finding records in a recordCollection. The
+	// function must return true if there is a hit, false otherwise.
+	FilterFunc func(a cloudflare.DNSRecord, b cloudflare.DNSRecord) bool
 )
 
+// Clone will make a copy of a recordCollection.
+func (c recordCollection) Clone() recordCollection {
+	result := recordCollection{}
+
+	result = append(result, c...)
+
+	return result
+}
+
+// Remove will remove the n'th element of c.
+func (c *recordCollection) Remove(n int) {
+	*c = append((*c)[:n], (*c)[n+1:]...)
+}
+
 // Find will search for needle in a recordCollection.
-func (c recordCollection) Find(needle cloudflare.DNSRecord) (int, *cloudflare.DNSRecord) {
+func (c recordCollection) Find(needle cloudflare.DNSRecord, match FilterFunc) (int, *cloudflare.DNSRecord) {
 	for i, r := range c {
 		if match(r, needle) {
 			return i, &r
@@ -25,28 +43,54 @@ func (c recordCollection) Find(needle cloudflare.DNSRecord) (int, *cloudflare.DN
 	return -1, nil
 }
 
-// Diff will find the differences between two recordCollections.
-func (c recordCollection) Diff(remote recordCollection) (recordCollection, recordCollection) {
-	localOnly := recordCollection{}
-	remoteOnly := recordCollection{}
+// Difference will find all the elements in c not present in remote [c \ remote].
+func (c recordCollection) Difference(remote recordCollection, match FilterFunc) recordCollection {
+	result := recordCollection{}
+	B := remote.Clone()
 
-	for _, l := range c {
-		n, _ := remote.Find(l)
+	for _, r := range c {
+		n, _ := B.Find(r, match)
 
 		if n < 0 {
-			localOnly = append(localOnly, l)
+			result = append(result, r)
+		} else {
+			B.Remove(n)
 		}
 	}
 
-	for _, r := range remote {
-		n, _ := c.Find(r)
+	return result
+}
 
-		if n < 0 {
-			remoteOnly = append(remoteOnly, r)
+// Intersect will find the intersection between c and remote [c ∩ remote] with
+// the caveat that the ID from c will be used in the result - while all other
+// properties will be copied from remote.
+func (c recordCollection) Intersect(remote recordCollection, match FilterFunc) recordCollection {
+	// Clone the inputs - we do this to be able to remove from these
+	// collections when a match is found.
+	A := c.Clone()
+	B := remote.Clone()
+	intersect := recordCollection{}
+
+	for i := 0; i < len(A); i++ {
+		found, hit := B.Find(A[i], match)
+		if found >= 0 {
+			// We do this trickery to keep the ID from the left part.
+			record := *hit
+			record.ID = A[i].ID
+
+			intersect = append(intersect, record)
+
+			// To make sure we're not double-spending we remove the found
+			// record from both inputs.
+			A.Remove(i)
+			B.Remove(found)
+
+			// Rewind the index to compensate for the item we just removed.
+			i--
 		}
 	}
 
-	return localOnly, remoteOnly
+	return intersect
 }
 
 // Fprint will output a textual representation of a recordCollection resembling
@@ -168,9 +212,9 @@ func newRecord(in *dns.Token) (*cloudflare.DNSRecord, error) {
 	return nil, fmt.Errorf("Record type %T is not supported", in.RR)
 }
 
-// match will do matching between two DNS records while ignoring CF specific
+// FullMatch will do matching between two DNS records while ignoring CF specific
 // details.
-func match(a cloudflare.DNSRecord, b cloudflare.DNSRecord) bool {
+func FullMatch(a cloudflare.DNSRecord, b cloudflare.DNSRecord) bool {
 	if a.Type != b.Type {
 		return false
 	}
@@ -200,4 +244,17 @@ func match(a cloudflare.DNSRecord, b cloudflare.DNSRecord) bool {
 	}
 
 	return false
+}
+
+// BasicMatch will return true if record type and name matches.
+func BasicMatch(a cloudflare.DNSRecord, b cloudflare.DNSRecord) bool {
+	if a.Type != b.Type {
+		return false
+	}
+
+	if a.Name != b.Name {
+		return false
+	}
+
+	return true
 }

--- a/recordCollection.go
+++ b/recordCollection.go
@@ -246,8 +246,9 @@ func FullMatch(a cloudflare.DNSRecord, b cloudflare.DNSRecord) bool {
 	return false
 }
 
-// BasicMatch will return true if record type and name matches.
-func BasicMatch(a cloudflare.DNSRecord, b cloudflare.DNSRecord) bool {
+// Updatable will return true if it makes sense to update (instead of
+// add/delete) from a to b or b to a.
+func Updatable(a cloudflare.DNSRecord, b cloudflare.DNSRecord) bool {
 	if a.Type != b.Type {
 		return false
 	}

--- a/recordCollection_test.go
+++ b/recordCollection_test.go
@@ -10,10 +10,63 @@ import (
 	cloudflare "github.com/cloudflare/cloudflare-go"
 )
 
+func TestClone(t *testing.T) {
+	a := recordCollection{}
+	b := a.Clone()
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("Clone() failed to clone an empty recordCollection")
+	}
+
+	a = recordCollection{
+		cloudflare.DNSRecord{Type: "A", Name: "a1", Content: "127.0.0.1"},
+		cloudflare.DNSRecord{Type: "A", Name: "a2", Content: "127.0.0.2"},
+		cloudflare.DNSRecord{Type: "A", Name: "a3", Content: "127.0.0.3"},
+		cloudflare.DNSRecord{Type: "A", Name: "a4", Content: "127.0.0.10"},
+		cloudflare.DNSRecord{Type: "A", Name: "a4", Content: "127.0.0.11"},
+		cloudflare.DNSRecord{Type: "A", Name: "a4", Content: "127.0.0.12"},
+		cloudflare.DNSRecord{Type: "A", Name: "a4", Content: "127.0.0.13"},
+		cloudflare.DNSRecord{Type: "AAAA", Name: "a1", Content: "::1"},
+		cloudflare.DNSRecord{Type: "MX", Name: "@", Content: "mail", Priority: 10},
+	}
+	b = a.Clone()
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("Clone() failed to clone a recordCollection")
+	}
+}
+
+func TestRemove(t *testing.T) {
+	in := recordCollection{
+		cloudflare.DNSRecord{Type: "A", Name: "a1", Content: "127.0.0.1", TTL: 100},
+		cloudflare.DNSRecord{Type: "A", Name: "a2", Content: "127.0.0.2", TTL: 200},
+		cloudflare.DNSRecord{Type: "A", Name: "a3", Content: "127.0.0.3", TTL: 300},
+		cloudflare.DNSRecord{Type: "A", Name: "a4", Content: "127.0.0.4", TTL: 400},
+	}
+
+	a := in.Clone()
+	a.Remove(1)
+	if !reflect.DeepEqual(a, recordCollection{
+		cloudflare.DNSRecord{Type: "A", Name: "a1", Content: "127.0.0.1", TTL: 100},
+		cloudflare.DNSRecord{Type: "A", Name: "a3", Content: "127.0.0.3", TTL: 300},
+		cloudflare.DNSRecord{Type: "A", Name: "a4", Content: "127.0.0.4", TTL: 400},
+	}) {
+		t.Errorf("Remove() did not return expected result")
+	}
+
+	a2 := in.Clone()
+	a2.Remove(1)
+	if !reflect.DeepEqual(a2, recordCollection{
+		cloudflare.DNSRecord{Type: "A", Name: "a1", Content: "127.0.0.1", TTL: 100},
+		cloudflare.DNSRecord{Type: "A", Name: "a3", Content: "127.0.0.3", TTL: 300},
+		cloudflare.DNSRecord{Type: "A", Name: "a4", Content: "127.0.0.4", TTL: 400},
+	}) {
+		t.Errorf("Remove() did not return expected result")
+	}
+}
+
 func TestFindEmpty(t *testing.T) {
 	c := recordCollection{}
 
-	n, r := c.Find(cloudflare.DNSRecord{})
+	n, r := c.Find(cloudflare.DNSRecord{}, FullMatch)
 	if n >= 0 {
 		t.Errorf("Find() returned a non-negative value from an empty collection")
 	}
@@ -23,7 +76,7 @@ func TestFindEmpty(t *testing.T) {
 	}
 }
 
-func TestMatch(t *testing.T) {
+func TestFullMatch(t *testing.T) {
 	cases := []struct {
 		a        cloudflare.DNSRecord
 		b        cloudflare.DNSRecord
@@ -40,7 +93,33 @@ func TestMatch(t *testing.T) {
 	}
 
 	for i, in := range cases {
-		result := match(in.a, in.b)
+		result := FullMatch(in.a, in.b)
+
+		if result != in.expected {
+			t.Errorf("%d: match() Returned unexpected result for %v, %v: %v (expected %v)", i, in.a, in.b, result, in.expected)
+		}
+	}
+}
+
+func TestBasicMatch(t *testing.T) {
+	cases := []struct {
+		a        cloudflare.DNSRecord
+		b        cloudflare.DNSRecord
+		expected bool
+	}{
+		{cloudflare.DNSRecord{Type: "A"}, cloudflare.DNSRecord{Type: "A"}, true},
+		{cloudflare.DNSRecord{Type: "A", Name: "a"}, cloudflare.DNSRecord{Type: "A", Name: "a"}, true},
+		{cloudflare.DNSRecord{Type: "A", Name: "a"}, cloudflare.DNSRecord{Type: "A", Name: "ab"}, false},
+		{cloudflare.DNSRecord{Type: "A", Name: "a", TTL: 0}, cloudflare.DNSRecord{Type: "A", Name: "a", TTL: 0}, true},
+		{cloudflare.DNSRecord{Type: "A", Name: "a", TTL: 0}, cloudflare.DNSRecord{Type: "A", Name: "a", TTL: 1}, true},
+		{cloudflare.DNSRecord{Type: "A", Name: "a", Proxied: true}, cloudflare.DNSRecord{Type: "A", Name: "a", Proxied: true}, true},
+		{cloudflare.DNSRecord{Type: "A", Name: "a", Proxied: true}, cloudflare.DNSRecord{Type: "A", Name: "a"}, true},
+		{cloudflare.DNSRecord{Type: "A", Name: "a", TTL: 0}, cloudflare.DNSRecord{Type: "A", Name: "a", TTL: 3600}, true},
+		{cloudflare.DNSRecord{Type: "CNAME", Name: "a", TTL: 0}, cloudflare.DNSRecord{Type: "A", Name: "a", TTL: 3600}, false},
+	}
+
+	for i, in := range cases {
+		result := BasicMatch(in.a, in.b)
 
 		if result != in.expected {
 			t.Errorf("%d: match() Returned unexpected result for %v, %v: %v (expected %v)", i, in.a, in.b, result, in.expected)
@@ -78,7 +157,7 @@ func TestFind(t *testing.T) {
 	}
 
 	for i, in := range cases {
-		n, r := c.Find(in.needle)
+		n, r := c.Find(in.needle, FullMatch)
 		if n != in.n {
 			t.Errorf("%d: Find() Returned unexpected n: %d (expected %d)", i, n, in.n)
 		}
@@ -89,35 +168,54 @@ func TestFind(t *testing.T) {
 	}
 }
 
-func TestDiff(t *testing.T) {
+func TestDifference(t *testing.T) {
 	empty := recordCollection{}
 	a1 := cloudflare.DNSRecord{Type: "A", Name: "test1", Content: "127.0.0.1"}
 	a2 := cloudflare.DNSRecord{Type: "A", Name: "test1", Content: "127.0.0.2"}
 	aaaa1 := cloudflare.DNSRecord{Type: "AAAA", Name: "test1", Content: "::1"}
 	cases := []struct {
-		a     recordCollection
-		b     recordCollection
-		aOnly recordCollection
-		bOnly recordCollection
+		a        recordCollection
+		b        recordCollection
+		expected recordCollection
 	}{
-		{empty, empty, empty, empty},
-		{empty, recordCollection{a1}, empty, recordCollection{a1}},
-		{recordCollection{a1}, empty, recordCollection{a1}, empty},
-		{empty, recordCollection{aaaa1}, empty, recordCollection{aaaa1}},
-		{recordCollection{aaaa1}, empty, recordCollection{aaaa1}, empty},
-		{recordCollection{aaaa1}, recordCollection{a1}, recordCollection{aaaa1}, recordCollection{a1}},
-		{recordCollection{a1, a2}, recordCollection{a1}, recordCollection{a2}, empty},
-		{recordCollection{a1, a2, a2}, recordCollection{a1}, recordCollection{a2, a2}, empty},
+		{empty, empty, empty},
+		{empty, recordCollection{a1}, empty},
+		{recordCollection{a1}, empty, recordCollection{a1}},
+		{empty, recordCollection{aaaa1}, empty},
+		{recordCollection{aaaa1}, empty, recordCollection{aaaa1}},
+		{recordCollection{aaaa1}, recordCollection{a1}, recordCollection{aaaa1}},
+		{recordCollection{a1, a2}, recordCollection{a1}, recordCollection{a2}},
+		{recordCollection{a1, a2, a2}, recordCollection{a1}, recordCollection{a2, a2}},
 	}
 
 	for i, in := range cases {
-		aOnly, bOnly := in.a.Diff(in.b)
-		if !reflect.DeepEqual(in.aOnly, aOnly) {
-			t.Errorf("%d: aOnly != in.aOnly, Got %+v, expcted %+v", i, aOnly, in.aOnly)
+		result := in.a.Difference(in.b, FullMatch)
+		if !reflect.DeepEqual(in.expected, result) {
+			t.Errorf("%d: aOnly != in.aOnly, Got %+v, expcted %+v", i, result, in.expected)
 		}
+	}
+}
 
-		if !reflect.DeepEqual(in.bOnly, bOnly) {
-			t.Errorf("%d: bOnly != in.bOnly, Got %v, expcted %v", i, bOnly, in.bOnly)
+func TestIntersect(t *testing.T) {
+	empty := recordCollection{}
+	a1 := cloudflare.DNSRecord{Type: "A", Name: "test1", Content: "127.0.0.1"}
+	aaaa1 := cloudflare.DNSRecord{Type: "AAAA", Name: "test1", Content: "::1"}
+	cases := []struct {
+		a        recordCollection
+		b        recordCollection
+		expected recordCollection
+	}{
+		{empty, empty, empty},
+		{empty, recordCollection{a1}, empty},
+		{recordCollection{a1}, empty, empty},
+		{recordCollection{a1}, recordCollection{a1}, recordCollection{a1}},
+		{empty, recordCollection{aaaa1}, empty},
+	}
+
+	for i, in := range cases {
+		result := in.a.Intersect(in.b, FullMatch)
+		if !reflect.DeepEqual(in.expected, result) {
+			t.Errorf("%d: aOnly != in.aOnly, Got %+v, expcted %+v", i, result, in.expected)
 		}
 	}
 }

--- a/recordCollection_test.go
+++ b/recordCollection_test.go
@@ -101,7 +101,7 @@ func TestFullMatch(t *testing.T) {
 	}
 }
 
-func TestBasicMatch(t *testing.T) {
+func TestUpdatable(t *testing.T) {
 	cases := []struct {
 		a        cloudflare.DNSRecord
 		b        cloudflare.DNSRecord
@@ -119,7 +119,7 @@ func TestBasicMatch(t *testing.T) {
 	}
 
 	for i, in := range cases {
-		result := BasicMatch(in.a, in.b)
+		result := Updatable(in.a, in.b)
 
 		if result != in.expected {
 			t.Errorf("%d: match() Returned unexpected result for %v, %v: %v (expected %v)", i, in.a, in.b, result, in.expected)


### PR DESCRIPTION
This PR adds support for updating existing DNS records instead of delete/add. Updates will be faster and downtime can be avoided for large edits.