### PR TITLE
Support split horizon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /cfzone
+# Ignore IDE files
+.idea

--- a/README.md
+++ b/README.md
@@ -7,17 +7,19 @@ This is a utility to update a cloudflare zone based on a bind-style [zone file](
 
 Only `A`, `AAAA`, `CNAME`, `MX`, and `TXT` records are supported.
 
-Cloudflare supported record types `LOC`, `NS`, `SRV`, `SPF` and `CAA` is not
+Cloudflare supported record types `LOC`, `NS`, `SRV`, `SPF` and `CAA` are not
 currently supported.
+
+Flags exist to skip `SRV` and `SPF` types.
 
 Cloudflare supports (at least) two modes not easily representable in a BIND
 zone. To support these features a few magic TTL values are used.
 
-| TTL | Status                                  |
-|-----|-----------------------------------------|
-| 0   | Automatic TTL, DNS only                 |
-| 1   | Automatic TTL, DNS and HTTP proxy (CDN) |
-| 2+  | Set as TTL, DNS only                    |
+| TTL           | Status                                  |
+|---------------|-----------------------------------------|
+| -autottl  (0) | Automatic TTL, DNS only                 |
+| -cachettl (1) | Automatic TTL, DNS and HTTP proxy (CDN) |
+| Other values  | Set as TTL, DNS only                    |
 
 Pull requests welcome :-)
 
@@ -34,10 +36,15 @@ Run cfzone as with the following command:
 
 Available optional flags:
 
-| Flag            | Description                                                 |
-|-----------------|-------------------------------------------------------------|
-| `-leaveunknown` | Don't delete unknown records                                |
-| `-yes`          | will cause cfzone to continue syncing without confirmation. |
+| Flag              | Description                                                        |
+|-------------------|--------------------------------------------------------------------|
+| `-leaveunknown`   | Don't delete unknown records                                       |
+| `-yes`            | will cause cfzone to continue syncing without confirmation.        |
+| `-autottl <int>`  | Specify the TTL to interpret as 'Auto' for Cloudflare (default 0)  |
+| `-cachettl <int>` | Specify the TTL to interpret as 'Cache' for Cloufdlare (default 1) |
+| `-ignorespf`      | Skip SPF records in the BIND zone file rather than erroring        |
+| `-ignoresrv`      | Skip SRV records in the BIND zone file rather than erroring        |
+| `-origin`         | Specify zone origin to resolve @ at the top level
 
 ## Building
 


### PR DESCRIPTION
The main motivation behind these changes is continuing to use BIND internally whilst enabling Cloudflare for public DNS. With that in mind, it is desirable to accept some records being un-syncable (e.g. SRV, which can be useful internally but non-critical externally), and to have 'magic' TTL values that are acceptable to use literally (0 in particular is notably unsuitable).
The other notable change is to support explicitly specifying the Origin of the zone file - this is significant if the BIND infrastructure imports the same definition in multiple origins.
There is also some tidying of PrintUsage, to make it more helpful and consistent.