### PR TITLE
Support multipart txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ Available optional flags:
 You'll need a working [Go environment](https://golang.org/doc/install) to build
 cfzone.
 
-`go get github.com/cego/cfzone` should retrieve the source code, build it and
+`go get github.com/third-light/cfzone` should retrieve the source code, build it and
 place the binary in `$GOPATH/bin/cfzone`.

--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ Available optional flags:
 You'll need a working [Go environment](https://golang.org/doc/install) to build
 cfzone.
 
-`go get github.com/third-light/cfzone` should retrieve the source code, build it and
+`go get github.com/cego/cfzone` should retrieve the source code, build it and
 place the binary in `$GOPATH/bin/cfzone`.

--- a/recordCollection.go
+++ b/recordCollection.go
@@ -216,7 +216,7 @@ func newRecord(in *dns.Token, autoTTL, cacheTTL int) (*cloudflare.DNSRecord, err
 	case *dns.TXT:
 		txt := in.RR.(*dns.TXT)
 		if len(txt.Txt) > 0 {
-			record.Content = txt.Txt[0]
+			record.Content = strings.Join(txt.Txt,"")
 		}
 		record.Type = "TXT"
 		return record, nil


### PR DESCRIPTION
Long TXT records - commonly DKIM keys - are split into multiple chunks in the BIND zone file. The Cloudflare record needs to contain all of the data, not just the first chunk.